### PR TITLE
Update StylusUtils.cpp

### DIFF
--- a/stylus-jni/src/main/cpp/dependencies/core/include/StylusUtils.h
+++ b/stylus-jni/src/main/cpp/dependencies/core/include/StylusUtils.h
@@ -24,5 +24,6 @@
 long GetJavaWindowId(JNIEnv * env, const jni::JavaLocalRef<jobject> & window);
 long GetJavaAwtWindowId(JNIEnv * env, const jni::JavaLocalRef<jobject> & window);
 long GetJavaFx9WindowId(JNIEnv * env, const jni::JavaLocalRef<jobject> & window);
+long GetComposeWindowId(JNIEnv * env, const jni::JavaLocalRef<jobject> & window);
 
 #endif


### PR DESCRIPTION
Added branching for predefined types, should introduce compatibility with jetpack compose and window frameworks exposing the window handle as a java.lang.Long, atleast on JNI side.

Be aware that i have never written anything complicated in C++ or with JNI, but this seems to work in all samples and 2 new test cases i made for my project.